### PR TITLE
Added reactionminersearch and chemdataextractorapi

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -3,4 +3,6 @@ Application is now running!
 Access http{{- if .Values.ingress.tls }}s{{- end }}://{{ .Values.ingress.hostname }}/docs to access chemscraper
 Access http{{- if .Values.ingress.tls }}s{{- end }}://yolo.{{ .Values.ingress.hostname }}/swagger-ui to access yolo
 Access http{{- if .Values.ingress.tls }}s{{- end }}://symbolscraper.{{ .Values.ingress.hostname }}/docs to access symbolscraper
-Access http{{- if .Values.ingress.tls }}s{{- end }}://qdgga.{{ .Values.ingress.hostname }}/docs to access qdgga
+Access http{{- if .Values.ingress.tls }}s{{- end }}://lgap.{{ .Values.ingress.hostname }}/docs to access LGAP
+Access http{{- if .Values.ingress.tls }}s{{- end }}://chemdataextractorapi.{{ .Values.ingress.hostname }}/docs to access chemdataextractorapi
+Access http{{- if .Values.ingress.tls }}s{{- end }}://reactionminersearch.{{ .Values.ingress.hostname }}/docs to access reactionminer_search

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
           ports:
             - containerPort: 8012
-        - name: reactionminer_search
+        - name: reactionminersearch
           image: {{ .Values.controller.images.reactionminer_search }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
           ports:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
           ports:
             - containerPort: 8012
+          env:
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: "compute,utility"
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
         - name: reactionminersearch
           image: {{ .Values.controller.images.reactionminer_search }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,6 +59,16 @@ spec:
               value: "compute,utility"
             - name: NVIDIA_VISIBLE_DEVICES
               value: "all"
+        - name: chemdataextractorapi
+          image: {{ .Values.controller.images.chemdataextractorapi }}
+          imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
+          ports:
+            - containerPort: 8012
+        - name: reactionminer_search
+          image: {{ .Values.controller.images.reactionminer_search }}
+          imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
+          ports:
+            - containerPort: 8013
           
 {{- if .Values.config.enableGPU | default false }}
           # If we set limits, then only this container can mount the GPU - exclude this to use for both prod + staging

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
             value: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
           - name: LGAP_SERVER_NAME
             value: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+          - name: REACTIONMINERSEARCH_SERVER_NAME
+            value: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+          - name: CHEMDATAEXTRACTORAPI_SERVER_NAME
+            value: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
           ports:
             - containerPort: 8000
         - name: symbolscraper

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -61,3 +61,23 @@ spec:
               number: 8007
         path: /
         pathType: ImplementationSpecific
+  - host: chemdataextractorapi.{{ .Values.ingress.hostname | required "required: ingress.hostname (e.g. chemscraper.backend.localhost)" }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port:
+              number: 8012
+        path: /
+        pathType: ImplementationSpecific
+  - host: reactionminersearch.{{ .Values.ingress.hostname | required "required: ingress.hostname (e.g. chemscraper.backend.localhost)" }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port:
+              number: 8013
+        path: /
+        pathType: ImplementationSpecific

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -15,6 +15,8 @@ spec:
     - yolo.{{ .Values.ingress.hostname }}
     - symbolscraper.{{ .Values.ingress.hostname }}
     - lgap.{{ .Values.ingress.hostname }}
+    - chemdataextractorapi.{{ .Values.ingress.hostname }}
+    - reactionminersearch.{{ .Values.ingress.hostname }}
     secretName: {{ .Values.ingress.hostname }}-tls
 {{- end }}
 {{- if .Values.ingress.ingressClassName }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -23,3 +23,11 @@ spec:
       protocol: TCP
       port: 8007
       targetPort: 8007
+    - name: chemdataextractorapi
+      protocol: TCP
+      port: 8012
+      targetPort: 8012
+    - name: reactionminersearch
+      protocol: TCP
+      port: 8013
+      targetPort: 8013

--- a/values.yaml
+++ b/values.yaml
@@ -11,8 +11,10 @@ controller:
   images: 
     yolo: dprl/yolov8server:latest
     symbolscraper: dprl/symbolscraper-server:latest
-    chemscraper: dprl/chemscraper:dev_v0.3.1
+    chemscraper: dprl/chemscraper:dev_v0.4.0
     lgap: dprl/lgap:latest
+    reactionminer_search: dprl/reactionminer_search:dev
+    chemdataextractorapi: sprl/chemdataextractorapi:dev
 
     #chemscraper: dprl/chemscraper:staging_v0.2.1
 

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ controller:
     chemscraper: dprl/chemscraper:dev_v0.4.0
     lgap: dprl/lgap:latest
     reactionminer_search: dprl/reactionminer_search:dev
-    chemdataextractorapi: sprl/chemdataextractorapi:dev
+    chemdataextractorapi: dprl/chemdataextractorapi:dev
 
     #chemscraper: dprl/chemscraper:staging_v0.2.1
 


### PR DESCRIPTION
## Problem
New RM+CS workflow now available

Requires new containers be deployed to the cluster

## Approach
* feat: deploy ChemScraper `dev_v0.4.0` to the cluster, along with 2 new containers: `chemdataextractorapi` + `reactionminersearch`

## How to Test
1. Navigate to [chemscraper-services-staging](https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu/docs#/default/index_pdfs_reactions_batch_index_pdfs_reactions_batch_post)
2. Follow the instructions from [dprl/dprl-alphasynthesis](https://gitlab.com/dprl/dprl-alphasynthesis/-/tree/dev_v0.4.0) to submit to the `/index_pdfs_reactions_batch` endpoint
    * For index name, you can send a unique string (e.g. `lambert8-test` or use job ID for a real job)
    * Add/upload a list of PDF files
    * Add/upload a list of JSON files (output from ReactionMiner)
    * Build up a `mapping.csv` that maps each PDF file to a JSON file - for us, the PDF file name and the JSON file name will typically match
3. Wait for your job to complete (it might take ~10 minutes)
4. Follow the instructions [dprl/dprl-alphasynthesis](https://gitlab.com/dprl/dprl-alphasynthesis/-/tree/dev_v0.4.0) to submit to the `/search` endpoint
    * Use the same index name as above
    * Use `text_query` to search for "compound"
    * Leave `smiles_query` blank for this example
5. Try it out with other inputs/searches