### PR TITLE
feat: mount new ChemScraper volumes for dev_v0.4.1

### DIFF
--- a/pvc.yaml
+++ b/pvc.yaml
@@ -1,0 +1,24 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mmli-chemscraper-index
+
+  #namespace: mmli              # Local cluster
+  #namespace: staging           # Staging
+  #namespace: alphasynthesis    # Production
+spec:
+  # Request a RWM volume
+  accessModes:
+    - ReadWriteMany
+
+  # from the NFS storage
+  storageClassName: nfs-taiga
+
+  # Size is ignored for NFS
+  resources:
+    requests:
+      storage: 10Gi
+
+
+

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
                     values:
                       - 'true'
 {{- end }}
+      volumes:
+        - name: chemscraperindex
+          persistentVolumeClaim:
+            claimName: {{ .Values.volumes.existingClaim }}
       containers:
         - name: chemscraper
           image: {{ .Values.controller.images.chemscraper }}
@@ -43,6 +47,10 @@ spec:
             value: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
           ports:
             - containerPort: 8000
+          volumeMounts:
+            - name: chemscraperindex
+              mountPath: /matching_files
+              subPath: matching_files
         - name: symbolscraper
           image: {{ .Values.controller.images.symbolscraper }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
@@ -78,6 +86,10 @@ spec:
           imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" }}
           ports:
             - containerPort: 8013
+          volumeMounts:
+            - name: chemscraperindex
+              mountPath: /index_store
+              subPath: index_store
           
 {{- if .Values.config.enableGPU | default false }}
           # If we set limits, then only this container can mount the GPU - exclude this to use for both prod + staging

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,9 @@ ingress:
 config:
   enableGPU: false
 
+volumes:
+  existingClaim: mmli-chemscraper-index
+
 controller:
   imagePullPolicy: Always
   images: 

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ controller:
   images: 
     yolo: dprl/yolov8server:latest
     symbolscraper: dprl/symbolscraper-server:latest
-    chemscraper: dprl/chemscraper:dev_v0.4.0
+    chemscraper: dprl/chemscraper:dev_v0.4.1
     lgap: dprl/lgap:latest
     reactionminer_search: dprl/reactionminer_search:dev
     chemdataextractorapi: dprl/chemdataextractorapi:dev


### PR DESCRIPTION
## Problem
We need to mount two new volumes to ChemScraper:
* `rectionminer_search` requires a volume mounted at `/index_store`
* `chemscraper` requires a volume mounted at `/matching_files`

## Approach
* feat: mount new ChemScraper volumes for [dev_v0.4.0](https://gitlab.com/dprl/dprl-alphasynthesis/-/blob/dev_v0.4.0/docker-compose.yml?ref_type=heads)
* feat: use latest version `dev_v0.4.1`